### PR TITLE
Implement target exec with Bolt transports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
         port: ${PORT}
         user: root
         password: root
+        host-key-check: false
   EOF
 - echo 'Validate with user Boltdir'
 - wash validate ./bolt
@@ -40,6 +41,7 @@ script:
         port: ${PORT}
         user: root
         password: root
+        host-key-check: false
   EOF
 - echo 'Validate with local Boltdir'
 - |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # boltwash
 
-A [Wash](https://puppetlabs.github.io/wash/) plugin for [Bolt](https://puppetlabs.github.io/bolt/). This plugin presents a view of Bolt targets organized by groups, and allows you to navigate their filesystems (currently only with SSH).
+A [Wash](https://puppetlabs.github.io/wash/) plugin for [Bolt](https://puppetlabs.github.io/bolt/). This plugin presents a view of Bolt targets organized by groups, and allows you to navigate their filesystems
 ```
 wash . > stree bolt
 bolt
@@ -75,6 +75,5 @@ The Bolt plugin for Wash provides an accessible, interactive means of investigat
 
 ## Future improvements
 
-* WinRM support
 * Bolt inventory plugins
 * Implement the 'metadata' method to retrieve facts


### PR DESCRIPTION
Adds support for all transports Bolt supports (except `remote`, because it's not obvious how that should operate). Switched SSH to it as well for consistency, because there would've been some cases where Wash's SSH functioned differently (`run-as`, `sudo-executable`, and `proxyjump` were ignored).

Signed-off-by: Michael Smith <michael.smith@puppet.com>