### PR TITLE
Fix new transports and specify loginshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ The Bolt plugin for Wash provides an accessible, interactive means of investigat
 
 > If you're a developer, you can use the bolt plugin from source with `bundle install` and set `script: /path/to/boltwash/bolt`.
 
+## Quirks
+
+When sending complex commands over WinRM, you can pass the command as a single string with appropriate escaping, as in
+```
+wash bolt/win > wexec target 'Get-Process | Where StartTime -gt $([DateTime]::Today)'
+```
+
 ## Future improvements
 
 * Bolt inventory plugins

--- a/bolt.rb
+++ b/bolt.rb
@@ -69,7 +69,7 @@ class Group < Wash::Entry
   end
 end
 
-def getshell(target)
+def get_login_shell(target)
   # Bolt's inventory defines a shell as a feature. Some transports provide
   # default features as well. Use these to determine the login shell.
   if target.features.include?('powershell')
@@ -87,7 +87,7 @@ class Target < Wash::Entry
   label 'target'
   parent_of VOLUMEFS
   state :target
-  attributes :loginshell
+  attributes :os
   description <<~DESC
     This is a target. You can view target configuration with the 'meta' command,
     and SSH to the target if it accepts SSH connections. If SSH works, the 'fs'
@@ -137,7 +137,9 @@ class Target < Wash::Entry
     @name = target.name
     @partial_metadata = target.detail
     @target = target.to_h
-    @loginshell = getshell(target)
+    if (shell = get_login_shell(target))
+      @os = { login_shell: shell }
+    end
     prefetch :list
   end
 

--- a/bolt.rb
+++ b/bolt.rb
@@ -69,10 +69,25 @@ class Group < Wash::Entry
   end
 end
 
+def getshell(target)
+  # Bolt's inventory defines a shell as a feature. Some transports provide
+  # default features as well. Use these to determine the login shell.
+  if target.features.include?('powershell')
+    'powershell'
+  elsif target.features.include?('bash')
+    'posixshell'
+  elsif target.transport == 'winrm'
+    'powershell'
+  elsif target.transport == 'ssh' || target.transport.nil?
+    'posixshell'
+  end
+end
+
 class Target < Wash::Entry
   label 'target'
   parent_of VOLUMEFS
   state :target
+  attributes :loginshell
   description <<~DESC
     This is a target. You can view target configuration with the 'meta' command,
     and SSH to the target if it accepts SSH connections. If SSH works, the 'fs'
@@ -122,6 +137,7 @@ class Target < Wash::Entry
     @name = target.name
     @partial_metadata = target.detail
     @target = target.to_h
+    @loginshell = getshell(target)
     prefetch :list
   end
 

--- a/bolt.rb
+++ b/bolt.rb
@@ -131,7 +131,6 @@ class Target < Wash::Entry
     # lazy-load dependencies to make the plugin as fast as possible
     require 'bolt/target'
     require 'logging'
-    require 'shellwords'
 
     # opts can contain 'tty', 'stdin', and 'elevate'. If tty is set, apply it
     # to the target for this exec.
@@ -141,7 +140,6 @@ class Target < Wash::Entry
 
     logger = Logging.logger($stderr)
     logger.level = :warn
-    command = Shellwords.join([cmd] + args)
 
     transport = target.transport || 'ssh'
     case transport
@@ -161,7 +159,7 @@ class Target < Wash::Entry
     begin
       connection.connect
       # Returns exit code
-      connection.execute(command, stdin: opts[:stdin])
+      connection.execute(cmd, args, stdin: opts[:stdin])
     ensure
       begin
         connection&.disconnect

--- a/transport_ssh.rb
+++ b/transport_ssh.rb
@@ -1,8 +1,6 @@
 require 'bolt/transport/base'
 require 'bolt/transport/sudoable'
 require 'bolt/transport/ssh/connection'
-require 'concurrent/atomic/atomic_reference'
-require 'concurrent/promises'
 
 class BoltSSH < Bolt::Transport::SSH::Connection
   # Adapted from Bolt::Transport::SSH::Connection.execute with output copied to
@@ -10,8 +8,13 @@ class BoltSSH < Bolt::Transport::SSH::Connection
   # handles stdin differently with sudo; it waits for some response, then
   # sends stdin.
   def execute(command, stdin: nil)
+    raise 'stdin not supported while using tty' if stdin && target.options['tty']
+
+    # If not nil, stdin==STDIN. Read all input so we have a string to pass around.
+    stdin = stdin.read if stdin
+
     escalate = run_as && @user != run_as
-    use_sudo = escalate && @target.options['run-as-command'].nil?
+    use_sudo = escalate && target.options['run-as-command'].nil?
 
     if escalate
       if use_sudo
@@ -19,7 +22,7 @@ class BoltSSH < Bolt::Transport::SSH::Connection
         sudo_flags = [sudo_exec, "-S", "-H", "-u", run_as, "-p", Bolt::Transport::Sudoable.sudo_prompt]
         sudo_str = Shellwords.shelljoin(sudo_flags)
       else
-        sudo_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
+        sudo_str = Shellwords.shelljoin(target.options['run-as-command'] + [run_as])
       end
       command = build_sudoable_command_str(command, sudo_str, @sudo_id, stdin: stdin, reset_cwd: true)
     end
@@ -37,17 +40,11 @@ class BoltSSH < Bolt::Transport::SSH::Connection
           )
         end
 
-        received = Concurrent::Promises.resolvable_future
-        # Automatically resolve it if we're not using sudo so we immediately send input
-        received.fulfill(true, false) unless use_sudo
-
         channel.on_data do |_, data|
-          received.fulfill(true, false)
           $stdout << data unless use_sudo && handled_sudo(channel, data, stdin)
         end
 
         channel.on_extended_data do |_, _, data|
-          received.fulfill(true, false)
           $stderr << data unless use_sudo && handled_sudo(channel, data, stdin)
         end
 
@@ -55,9 +52,8 @@ class BoltSSH < Bolt::Transport::SSH::Connection
           exit_code = data.read_long
         end
 
-        # Wait until we know sudo is handled, then send stdin.
-        if stdin && received.value!
-          channel.send_data(options[:stdin])
+        if stdin && !use_sudo
+          channel.send_data(stdin)
           channel.eof!
         end
       end

--- a/transport_ssh.rb
+++ b/transport_ssh.rb
@@ -1,13 +1,15 @@
 require 'bolt/transport/base'
 require 'bolt/transport/sudoable'
 require 'bolt/transport/ssh/connection'
+require 'shellwords'
 
 class BoltSSH < Bolt::Transport::SSH::Connection
   # Adapted from Bolt::Transport::SSH::Connection.execute with output copied to
   # $stdout/$stderr. Returns an exit code instead of Bolt::Result. It also
   # handles stdin differently with sudo; it waits for some response, then
   # sends stdin.
-  def execute(command, stdin: nil)
+  def execute(cmd, args, stdin: nil)
+    command = Shellwords.join([cmd] + args)
     raise 'stdin not supported while using tty' if stdin && target.options['tty']
 
     # If not nil, stdin==STDIN. Read all input so we have a string to pass around.

--- a/transport_winrm.rb
+++ b/transport_winrm.rb
@@ -4,12 +4,16 @@ require 'winrm'
 
 class BoltWinRM < Bolt::Transport::WinRM::Connection
   # Override execute so it streams output and returns the exit code
-  def execute(command, stdin: nil)
+  def execute(cmd, args, stdin: nil)
     # The WinRM gem doesn't provide a way to pass stdin. It would require
     # sending a whole script to make it work and we don't have a lot of cases
     # where it's needed yet.
     raise 'input on stdin not supported' if stdin
 
+    # The powershell implementation ignores 'args', so just string join (which
+    # is how powershell joins arg arrays). If you use characters that need to be
+    # escaped, pass the argument as a single string with appropriate escaping.
+    command = ([cmd] + args).join(' ')
     output = @session.run(command) do |stdout, stderr|
       $stdout << stdout
       $stderr << stderr


### PR DESCRIPTION
The switch to using Bolt transport connections broke handling stdin. This fixes it.

It was broken on Windows. Switch to passing command and arguments, and individual transports can join them as needed.

Specifies the `loginshell` attribute. This is used by Wash commands, `volume.FS`, and can be used by Wash users to select what kind of commands they can run on an entry. Select posix shell or powershell based on Bolt features and transports.